### PR TITLE
Set up Biome as formatter and linter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,9 +11,12 @@ Wikipedian is a Discord bot that provides a `/wikipedia` slash command for searc
 - `npm install` — install dependencies
 - `npm run tsc` — compile TypeScript (src/ → dist/)
 - `npm run start` — run the bot (`node dist/index.js`)
+- `npm run format` — format code with Biome (`biome format --write src/`)
+- `npm run lint` — lint code with Biome (`biome lint src/`)
+- `npm run check` — format + lint in one pass with Biome (`biome check --write src/`)
 - Slash commands are automatically registered on bot startup (requires `.env` with `WIKIPEDIAN_CLIENT_ID` and `WIKIPEDIAN_TOKEN`)
 
-There is no test framework configured.
+There is no test framework configured. Biome is used for formatting and linting.
 
 ## Architecture
 

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,20 @@
+{
+	"$schema": "https://biomejs.dev/schemas/2.3.14/schema.json",
+	"formatter": {
+		"indentStyle": "space",
+		"indentWidth": 4
+	},
+	"linter": {
+		"enabled": true
+	},
+	"assist": {
+		"actions": {
+			"source": {
+				"organizeImports": "on"
+			}
+		}
+	},
+	"files": {
+		"includes": ["src/**"]
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,172 @@
         "discord.js": "^14.25.1",
         "dotenv": "^17.2.4"
       },
-      "devDependencies": {}
+      "devDependencies": {
+        "@biomejs/biome": "2.3.14"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.3.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.3.14.tgz",
+      "integrity": "sha512-QMT6QviX0WqXJCaiqVMiBUCr5WRQ1iFSjvOLoTk6auKukJMvnMzWucXpwZB0e8F00/1/BsS9DzcKgWH+CLqVuA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.3.14",
+        "@biomejs/cli-darwin-x64": "2.3.14",
+        "@biomejs/cli-linux-arm64": "2.3.14",
+        "@biomejs/cli-linux-arm64-musl": "2.3.14",
+        "@biomejs/cli-linux-x64": "2.3.14",
+        "@biomejs/cli-linux-x64-musl": "2.3.14",
+        "@biomejs/cli-win32-arm64": "2.3.14",
+        "@biomejs/cli-win32-x64": "2.3.14"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.3.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.3.14.tgz",
+      "integrity": "sha512-UJGPpvWJMkLxSRtpCAKfKh41Q4JJXisvxZL8ChN1eNW3m/WlPFJ6EFDCE7YfUb4XS8ZFi3C1dFpxUJ0Ety5n+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.3.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.3.14.tgz",
+      "integrity": "sha512-PNkLNQG6RLo8lG7QoWe/hhnMxJIt1tEimoXpGQjwS/dkdNiKBLPv4RpeQl8o3s1OKI3ZOR5XPiYtmbGGHAOnLA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.3.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.3.14.tgz",
+      "integrity": "sha512-KT67FKfzIw6DNnUNdYlBg+eU24Go3n75GWK6NwU4+yJmDYFe9i/MjiI+U/iEzKvo0g7G7MZqoyrhIYuND2w8QQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.3.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.3.14.tgz",
+      "integrity": "sha512-LInRbXhYujtL3sH2TMCH/UBwJZsoGwfQjBrMfl84CD4hL/41C/EU5mldqf1yoFpsI0iPWuU83U+nB2TUUypWeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.3.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.3.14.tgz",
+      "integrity": "sha512-ZsZzQsl9U+wxFrGGS4f6UxREUlgHwmEfu1IrXlgNFrNnd5Th6lIJr8KmSzu/+meSa9f4rzFrbEW9LBBA6ScoMA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.3.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.3.14.tgz",
+      "integrity": "sha512-KQU7EkbBBuHPW3/rAcoiVmhlPtDSGOGRPv9js7qJVpYTzjQmVR+C9Rfcz+ti8YCH+zT1J52tuBybtP4IodjxZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.3.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.3.14.tgz",
+      "integrity": "sha512-+IKYkj/pUBbnRf1G1+RlyA3LWiDgra1xpS7H2g4BuOzzRbRB+hmlw0yFsLprHhbbt7jUzbzAbAjK/Pn0FDnh1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.3.14",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.3.14.tgz",
+      "integrity": "sha512-oizCjdyQ3WJEswpb3Chdngeat56rIdSYK12JI3iI11Mt5T5EXcZ7WLuowzEaFPNJ3zmOQFliMN8QY1Pi+qsfdQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
     },
     "node_modules/@discordjs/builders": {
       "version": "1.13.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "main": "index.js",
   "scripts": {
     "tsc": "tsc",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "format": "biome format --write src/",
+    "lint": "biome lint src/",
+    "check": "biome check --write src/"
   },
   "dependencies": {
     "cheerio": "^1.2.0",
@@ -10,5 +13,6 @@
     "dotenv": "^17.2.4"
   },
   "devDependencies": {
+    "@biomejs/biome": "2.3.14"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,54 +1,68 @@
-require('dotenv').config();
+require("dotenv").config();
 
-import { ChatInputCommandInteraction, Client, CacheType, REST, Routes, SlashCommandBuilder } from 'discord.js';
-import { load } from 'cheerio';
-
+import { load } from "cheerio";
+import {
+    type CacheType,
+    type ChatInputCommandInteraction,
+    Client,
+    REST,
+    Routes,
+    SlashCommandBuilder,
+} from "discord.js";
 
 const registerCommands = async () => {
     const clientId = process.env.WIKIPEDIAN_CLIENT_ID;
     const token = process.env.WIKIPEDIAN_TOKEN;
 
     if (!clientId || !token) {
-        throw new Error('WIKIPEDIAN_CLIENT_ID and WIKIPEDIAN_TOKEN must be set');
+        throw new Error(
+            "WIKIPEDIAN_CLIENT_ID and WIKIPEDIAN_TOKEN must be set",
+        );
     }
 
     const commands = [
         new SlashCommandBuilder()
-            .setName('wikipedia')
-            .setDescription('Search Article from Wikipedia')
-            .addStringOption(option =>
-                option.setName("word")
+            .setName("wikipedia")
+            .setDescription("Search Article from Wikipedia")
+            .addStringOption((option) =>
+                option
+                    .setName("word")
                     .setDescription("検索語")
-                    .setRequired(true))
-            .addStringOption(option =>
-                option.setName("languages")
-                    .setDescription("言語('en', 'ja', 'fr', 'en,ja,fr' など。デフォルトはja)")),
-    ].map(command => command.toJSON());
+                    .setRequired(true),
+            )
+            .addStringOption((option) =>
+                option
+                    .setName("languages")
+                    .setDescription(
+                        "言語('en', 'ja', 'fr', 'en,ja,fr' など。デフォルトはja)",
+                    ),
+            ),
+    ].map((command) => command.toJSON());
 
-    const rest = new REST({ version: '10' }).setToken(token);
+    const rest = new REST({ version: "10" }).setToken(token);
     await rest.put(Routes.applicationCommands(clientId), { body: commands });
-    console.log('コマンド登録完了');
+    console.log("コマンド登録完了");
 };
 
 const main = async () => {
     try {
         await registerCommands();
     } catch (e) {
-        console.error('コマンド登録失敗:', e);
+        console.error("コマンド登録失敗:", e);
     }
 
     const client = new Client({ intents: [] });
 
-    client.once('ready', () => {
-        console.log('起動完了');
+    client.once("ready", () => {
+        console.log("起動完了");
     });
 
-    client.on('interactionCreate', async interaction => {
+    client.on("interactionCreate", async (interaction) => {
         if (!interaction.isCommand()) return;
 
         const { commandName } = interaction;
 
-        if (commandName === 'wikipedia' && interaction.isChatInputCommand()) {
+        if (commandName === "wikipedia" && interaction.isChatInputCommand()) {
             wikipedia_command(interaction);
         }
     });
@@ -56,50 +70,68 @@ const main = async () => {
     client.login(process.env.WIKIPEDIAN_TOKEN);
 };
 
-const wikipedia_command = async (interaction: ChatInputCommandInteraction<CacheType>) => {
+const wikipedia_command = async (
+    interaction: ChatInputCommandInteraction<CacheType>,
+) => {
     const raw_word = interaction.options.get("word")?.value?.toString();
-    const languages = (interaction.options.get("languages")?.value?.toString() ?? "ja").split(",");
+    const languages = (
+        interaction.options.get("languages")?.value?.toString() ?? "ja"
+    ).split(",");
 
     if (!raw_word) {
         interaction.reply("words cannot be parsed.");
         return;
     }
 
-    interaction.reply((await Promise.all(languages.map((language: string) => search_wikipedia(language, raw_word)))).join("\n"));
+    interaction.reply(
+        (
+            await Promise.all(
+                languages.map((language: string) =>
+                    search_wikipedia(language, raw_word),
+                ),
+            )
+        ).join("\n"),
+    );
+};
 
-}
-
-const search_wikipedia = async (language: string, raw_word: string): Promise<string> => {
-
+const search_wikipedia = async (
+    language: string,
+    raw_word: string,
+): Promise<string> => {
     const word = raw_word.replace(/ /g, "_");
     const URL = `https://${language}.wikipedia.org/wiki/${word}`;
-    console.log("request: " + URL);
+    console.log(`request: ${URL}`);
 
     const res = await fetch(URL);
 
-    if (res.status == 404) {
-        console.log(URL + " is not found.");
+    if (res.status === 404) {
+        console.log(`${URL} is not found.`);
         return `${language}: "${raw_word}" is not found.`;
     }
 
     if (res.status >= 400) {
-        console.log(URL + `: error code ${res.status}`);
+        console.log(`${URL}: error code ${res.status}`);
         return `${language}: "${raw_word}": error code ${res.status}`;
     }
 
     const rawHTML = await res.text();
 
     if (rawHTML == null) {
-        console.log(URL + `: HTML is empty.`);
+        console.log(`${URL}: HTML is empty.`);
         return `${language}: "${raw_word}" is not found.`;
     }
 
-    console.log(URL + " is found.");
+    console.log(`${URL} is found.`);
 
-    const HTML = load(rawHTML)
-    const text = language + ": \"" + raw_word + "\"\n" +
-        HTML('.mw-parser-output').find('p:eq(0)').text().trim() +
-        HTML('.mw-parser-output').find('p:eq(1)').text().trim() + "\n" +
+    const HTML = load(rawHTML);
+    const text =
+        language +
+        ': "' +
+        raw_word +
+        '"\n' +
+        HTML(".mw-parser-output").find("p:eq(0)").text().trim() +
+        HTML(".mw-parser-output").find("p:eq(1)").text().trim() +
+        "\n" +
         URL;
 
     if (text) {


### PR DESCRIPTION
## Summary
- Install Biome v2 as a dev dependency and add `biome.json` config (4-space indentation, linting enabled, scoped to `src/`)
- Add `npm run format`, `npm run lint`, and `npm run check` scripts to `package.json`
- Auto-fix existing code: consistent double quotes, template literals, strict equality (`===`), import organization, `type` keyword on type-only imports
- Document new commands in `CLAUDE.md`

Closes #5

## Test plan
- [x] `npm run check` exits 0
- [x] `npm run tsc` still compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)