### PR TITLE
feat: add Docker build and run scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "lint": "biome lint src/",
     "check": "biome check --write src/",
     "typecheck": "tsc --noEmit",
-    "test:docker": "docker compose -f docker-compose.test.yml up --build --abort-on-container-exit --exit-code-from test-runner"
+    "test:docker": "docker compose -f docker-compose.test.yml up --build --abort-on-container-exit --exit-code-from test-runner",
+    "docker:build": "docker build -t wikipedian .",
+    "docker:run": "bun run docker:build && docker run --env-file .env wikipedian"
   },
   "dependencies": {
     "cheerio": "^1.2.0",


### PR DESCRIPTION
## Summary
- Add `docker:build` script to build the Docker image locally
- Add `docker:run` script to build and run the bot in Docker with `.env` file

## Test plan
- [ ] Verify `bun run docker:build` builds the image successfully
- [ ] Verify `bun run docker:run` starts the bot with environment variables from `.env`

🤖 Generated with [Claude Code](https://claude.com/claude-code)