### PR TITLE
fix: change Docker image push destination to GHCR

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,10 +12,10 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
-      - name: Log in to GitHub Docker Registry
+      - name: Log in to GitHub Container Registry
         uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7 # v1
         with:
-          registry: docker.pkg.github.com
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Get tag
@@ -26,5 +26,5 @@ jobs:
         with:
           push: true
           tags: |
-            docker.pkg.github.com/${{ github.repository }}/wikipedian:${{ steps.get_tag.outputs.TAG }}
-            docker.pkg.github.com/${{ github.repository }}/wikipedian:latest
+            ghcr.io/${{ github.repository }}/wikipedian:${{ steps.get_tag.outputs.TAG }}
+            ghcr.io/${{ github.repository }}/wikipedian:latest


### PR DESCRIPTION
## Summary
- Migrate release workflow from deprecated `docker.pkg.github.com` to `ghcr.io` (GitHub Container Registry)
- Update login action registry and image tags in `.github/workflows/release.yaml`
- This aligns the CI push target with the Kubernetes manifest (`manifests/wikipedian.yaml`) which already references `ghcr.io`

## Test plan
- [ ] Verify release workflow triggers correctly on next release
- [ ] Confirm image is pushed to `ghcr.io/yuchiki/wikipedian/wikipedian`
- [ ] Verify Kubernetes deployment can pull the new image

Fixes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)