### PR TITLE
fix: update release workflow to fix GHCR push failure

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,16 +4,16 @@ on:
     types: [published]
 jobs:
   push_to_registry:
-    name: Push Docker image to GitHub Packages
+    name: Push Docker image to GHCR
     runs-on: ubuntu-latest
     permissions:
       packages: write
       contents: read
     steps:
       - name: Check out the repo
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7 # v1
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -21,10 +21,11 @@ jobs:
       - name: Get tag
         id: get_tag
         run: echo "TAG=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
-      - name: Build container image
-        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2
+      - name: Build and push container image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
+          context: .
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}/wikipedian:${{ steps.get_tag.outputs.TAG }}
-            ghcr.io/${{ github.repository }}/wikipedian:latest
+            ghcr.io/${{ github.repository }}:${{ steps.get_tag.outputs.TAG }}
+            ghcr.io/${{ github.repository }}:latest

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ WIKIPEDIAN_TOKEN=メモしたトークン
 ### Docker の場合
 
 ```sh
-docker pull ghcr.io/yuchiki/wikipedian/wikipedian:latest
-docker run --env-file=.env ghcr.io/yuchiki/wikipedian/wikipedian
+docker pull ghcr.io/yuchiki/wikipedian:latest
+docker run --env-file=.env ghcr.io/yuchiki/wikipedian
 ```
 
 ### Kubernetes の場合

--- a/manifests/wikipedian.yaml
+++ b/manifests/wikipedian.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: wikipedian
-        image: ghcr.io/yuchiki/wikipedian/wikipedian
+        image: ghcr.io/yuchiki/wikipedian
         env:
         - name: WIKIPEDIAN_TOKEN
           valueFrom:


### PR DESCRIPTION
## Summary

- Update all GitHub Actions in `release.yaml` from v1/v2 to their latest versions (checkout v4, login-action v3, build-push-action v6) with pinned SHAs
- Fix the image tag path from `ghcr.io/yuchiki/wikipedian/wikipedian` to `ghcr.io/yuchiki/wikipedian` (remove redundant path segment)
- Update Kubernetes manifest and README to match the corrected image path

## Root Cause

The old `docker/build-push-action@v2` (SHA `ac9327ea...`) was pushing to the deprecated `docker.pkg.github.com` registry instead of `ghcr.io`, even though the tags specified `ghcr.io`. The login step authenticated against `ghcr.io`, but the push went to `docker.pkg.github.com`, resulting in `401 Unauthorized` errors.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/release.yaml` | Updated all action versions, added `context: .`, fixed image tags |
| `manifests/wikipedian.yaml` | Updated image reference to `ghcr.io/yuchiki/wikipedian` |
| `README.md` | Updated Docker pull/run commands to match new image path |

## Test plan

- [x] Unit tests pass (`bun test`)
- [x] Biome lint/format pass
- [ ] Verify by creating a new release and confirming the image is pushed to GHCR successfully

Fixes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)